### PR TITLE
Small fixed for all readme files

### DIFF
--- a/addon/doc/en.md
+++ b/addon/doc/en.md
@@ -29,7 +29,7 @@ MarkdownForever is a small NVDA add-on that converts Markdown or HTML contents e
 MarkdownForever can:
 
 * Convert Markdown to HTML
-* Convert markdown to HTML source code
+* Convert Markdown to HTML source code
 * Convert HTML to Markdown
 * Convert Markdown to formatted HTML
 
@@ -80,7 +80,7 @@ You can even put `*some text in italic*` by enclosing it in asterisks, or `**wri
 
 ## Converting Markdown to HTML
 
-This feature allows you to convert any markdown text displayed on the screen to HTML, showing you the way your Markdown will look in the final HTML document. This can be a document you have written in Markdown format, a .md file you already have on your hard drive or a Markdown text found on a web page. By default, MarkdownForever converts all the currently displayed text, but you can also select only a specific part to be converted.
+This feature allows you to convert any Markdown text displayed on the screen to HTML, showing you the way your Markdown will look in the final HTML document. This can be a document you have written in Markdown format, a .md file you already have on your hard drive or a Markdown text found on a web page. By default, MarkdownForever converts all the currently displayed text, but you can also select only a specific part to be converted.
 
 You can use the following commands:
 
@@ -220,7 +220,7 @@ They can be reached from the NVDA menu -> Settings MarkdownForever -> Settings a
 - *NVDA+CTRL+i*: Interactive mode.
 - *NVDA+ALT+b*: Markdown to HTML conversion. The result is displayed in your default browser.
 - *NVDA+ALT+n*: Markdown to HTML conversion. The result is displayed in a virtual buffer of NVDA.
-- *NVDA+ALT+k*: HTML to markdown conversion. The result is displayed in a virtual buffer of NVDA.
+- *NVDA+ALT+k*: HTML to Markdown conversion. The result is displayed in a virtual buffer of NVDA.
 - *NVDA+ALT+l*: Markdown to HTML source conversion. The result is displayed in a virtual buffer of NVDA.
 - *NVDA+SHIFT+g*: HTML to Markdown conversion. The result is copied to clipboard.
 - *NVDA+SHIFT+h*: Markdown to formatted HTML conversion: The result is copied to the clipboard.

--- a/addon/doc/fr.md
+++ b/addon/doc/fr.md
@@ -80,7 +80,7 @@ ce qui vous donnera :
 
 [Cliquez ici pour visiter le site Web de NVAccess](https://www.nvaccess.org)
  
-Vous avez même la possibilité de mettre `*du texte en italique*` en l'entourant d'astérisques, ou `**écrire du texte en gras**` en l'entourant de deux astérisques... Les possibilités sont nombreuses. Vous pouvez par exemple consulter ce [petit guide pour bien commencer avec markdown](https://blog.wax-o.com/2014/04/tutoriel-un-guide-pour-bien-commencer-avec-markdown/) afin d'en savoir plus.
+Vous avez même la possibilité de mettre `*du texte en italique*` en l'entourant d'astérisques, ou `**écrire du texte en gras**` en l'entourant de deux astérisques... Les possibilités sont nombreuses. Vous pouvez par exemple consulter ce [petit guide pour bien commencer avec Markdown](https://blog.wax-o.com/2014/04/tutoriel-un-guide-pour-bien-commencer-avec-markdown/) afin d'en savoir plus.
 
 ## Conversion de Markdown en HTML
 

--- a/addon/doc/tr.md
+++ b/addon/doc/tr.md
@@ -210,7 +210,7 @@ Bunlara NVDA menüsü / MarkdownForever Ayarları / Ayarlar yolundan erişilebil
 * "Özel etiketleri Etkinleştir": Bu işaretlenirse, gerçek tarih veya saat gibi şeyleri otomatik olarak eklemek için Markdown içeriğinizde [özel etiketler](#extra-tags) kullanma olanağı sağlar. Bu davranış, [isteğe bağlı meta veri bloğundaki](#optional-metadata-block) "extratags" anahtarı kullanılarak belge başına da ayarlanabilir.
 * "HTML kaynağı için karşılık gelen meta veriler oluştur": Bir HTML kaynak dosyasını Markdown'a dönüştürürken, meta verileri kaynak koddan (başlık, dil, dosya adı vb.) tahmin etmeye çalışır ve [meta veri bloğu](#optionnal-metadata-block)unu sizin oluşturur.
 * "Etkileşimli modda varsayılan eylem": Bu, [Etkileşimli mod](#interactive-mode)da enter tuşuna basıldığında gerçekleştirilecek varsayılan eylemi seçmenize olanak tanır: (Oluşturulan içeriği tarayıcınızda, NVDA  geçici arabelleğindde gösterebilir veya panoya kopyalayabilirsiniz.
-* "markdown motoru": MarkdownForever iki dönüşüm motoru arasında seçim yapmanızı sağlar, [HTML2Text](https://pypi.org/project/html2text/) ve [HTML2Markdown.](https://pypi.org/project/html2markdown/) İhtiyacınıza veya üretilen sonuca göre tercih ettiğiniz ürünü deneyin ve seçin.
+* "Markdown motoru": MarkdownForever iki dönüşüm motoru arasında seçim yapmanızı sağlar, [HTML2Text](https://pypi.org/project/html2text/) ve [HTML2Markdown.](https://pypi.org/project/html2markdown/) İhtiyacınıza veya üretilen sonuca göre tercih ettiğiniz ürünü deneyin ve seçin.
 * "Markdown2 ekstraları": şuna bakın <https://github.com/trentm/python-markdown2/wiki/Extras>.
 * "yol": Burada, dönüştürülen belgeleriniz için sabit diskinizde varsayılan bir kaydetme konumu belirleyebilirsiniz. tüm çalışmalarınızı saklamak için her zaman aynı klasörü kullanmanız yararlı olur.
 * "HTML şablonlarını yönet": Bu, HTML şablonları eklemeye, düzenlemeye ve silmeye izin veren bir iletişim kutusu açar. Şablonlarla, sayfa stilinden sorumlu olan CSS (basamaklı stil sayfaları) kullanarak oluşturulan HTML belgelerinizin görsel yönlerini özelleştirebilirsiniz. Bu, renkleri değiştirmenize, yapımlarınıza görüntü  veya resimler eklemenize ve her özel ihtiyaç için bir şablon oluşturmanıza olanak tanır. Tabii ki web üzerinde CSS öğrenmek için birçok öğretici var,  mesela [bu](https://www.htmldog.com/guides/css/beginner/) iyi bir başlangıç noktası olabilir.
@@ -220,7 +220,7 @@ Bunlara NVDA menüsü / MarkdownForever Ayarları / Ayarlar yolundan erişilebil
 - *NVDA+CTRL+i*: Etkileşimli mod
 - *NVDA+ALT+b*: Markdown'dan HTML'e dönüştürür. Sonuç varsayılan tarayıcınızda görüntülenir.
 - *NVDA+ALT+n*: Markdown'dan HTML'e dönüştürür. Sonuç, NVDA'nın geçici arabelleğinde gösterilir.
-- *NVDA+ALT+k*: HTML'den markdown'a dönüştürür. Sonuç NVDA'nın geçici arabelleğinde gösterilir.
+- *NVDA+ALT+k*: HTML'den Markdown'a dönüştürür. Sonuç NVDA'nın geçici arabelleğinde gösterilir.
 - *NVDA+ALT+l*: Markdown'dan kaynak HTML'e dönüştürür. Sonuç NVDA'nın geçici arabelleğinde gösterilir.
 - *NVDA+SHIFT+g*: HTML'den Markdown'a dönüştürür. Sonuç panoya kopyalanır.
 - *NVDA+SHIFT+h*: Markdown'dan biçimlendirilmiş HTML'e dönüştürür: Sonuç panoya kopyalanır.

--- a/addon/doc/vi.md
+++ b/addon/doc/vi.md
@@ -29,7 +29,7 @@ MarkdownForever là một add-on nhỏ cho NVDA, dùng để chuyển đổi n�
 MarkdownForever có thể:
 
 * Chuyển đổi Markdown thành HTML
-* Chuyển đổi markdown thành mã nguồn HTML
+* Chuyển đổi Markdown thành mã nguồn HTML
 * Chuyển đổi HTML thành Markdown
 * Chuyển đổi Markdown thành định dạng HTML
 
@@ -80,7 +80,7 @@ Thậm chí, bạn có thể `*in nghiêng một đoạn văn bản*` bằng cá
 
 ## Chuyển đổi Markdown thành HTML
 
-Tính năng này cho phép bạn chuyển nội dung markdown hiển thị trên màn hình thành HTML, hiển thị như cách mà nội dung  Markdown của bạn sẽ thể hiện ở tài liệu HTML. Đây có thể là một tài liệu được viết ở định dạng Markdown, một tập tin .md có sẵn trên ổ cứng hoặc một nội dung Markdown tìm thấy trên một trang web. Mặc định, MarkdownForever sẽ chuyển tất cả nội dung đang hiển thị, nhưng bạn cũng có thể chọn một đoạn nhất định để chuyển đổi.
+Tính năng này cho phép bạn chuyển nội dung Markdown hiển thị trên màn hình thành HTML, hiển thị như cách mà nội dung  Markdown của bạn sẽ thể hiện ở tài liệu HTML. Đây có thể là một tài liệu được viết ở định dạng Markdown, một tập tin .md có sẵn trên ổ cứng hoặc một nội dung Markdown tìm thấy trên một trang web. Mặc định, MarkdownForever sẽ chuyển tất cả nội dung đang hiển thị, nhưng bạn cũng có thể chọn một đoạn nhất định để chuyển đổi.
 
 Bạn có thể dùng các phím lệnh sau:
 
@@ -220,7 +220,7 @@ Có thể truy cập chúng từ trình đơn NVDA -> Cài đặt MarkdownForeve
 - *NVDA+CTRL+i*: chế độ tương tác.
 - *NVDA+ALT+b*: chuyển đổi Markdown thành HTML. Kết quả hiển thị trên trình duyệt mặc định.
 - *NVDA+ALT+n*: chuyển đổi Markdown thành HTML. Kết quả hiển thị trên màn hình ảo của NVDA.
-- *NVDA+ALT+k*: chuyển đổi HTML thành markdown. Kết quả hiển thị trên màn hình ảo của NVDA.
+- *NVDA+ALT+k*: chuyển đổi HTML thành Markdown. Kết quả hiển thị trên màn hình ảo của NVDA.
 - *NVDA+ALT+l*: chuyển đổi Markdown thành mã nguồn HTML. Kết quả hiển thị trên màn hình ảo của NVDA.
 - *NVDA+SHIFT+g*: chuyển đổi HTML thành Markdown. Kết quả được chép vào bộ nhớ tạm.
 - *NVDA+SHIFT+h*: chuyển đổi Markdown thành định dạng HTML . kết quả được chép vào bộ nhớ tạm.


### PR DESCRIPTION
Small fix for all readme files, where some work "Markdown" were written in lowercase at its first letter, while most of the rest were written Uppercase.