### PR TITLE
Vietnamese: Corrected wrong address in toc

### DIFF
--- a/addon/doc/vi.md
+++ b/addon/doc/vi.md
@@ -4,7 +4,7 @@ author:
 autonumber-headings: 1
 css:
 - style.css
-date: Thứ ba, 19/05/2020
+date: Chủ nhật, 26/07/2020
 extratags: 1
 extratags-back: 0
 filename: doc_vi
@@ -41,7 +41,7 @@ Theo Wikipedia,
 
 Bạn có thể tìm hiểu thêm về Markdown bằng cách đọc [bài viết đầy đủ trên Wikipedia.](https://vi.wikipedia.org/wiki/Markdown)
 
-Như vậy, thay vì viết tài liệu web bằng HTML với nguy cơ tạo tài liệu bị lỗi, bạn sẽ dùng các thẻ dễ nhớ hơn và công việc của bạn sẽ hoàn thành nhanh chóng. Với Markdown, bạn sẽ làm được nhiều hoặc ít hơn những gì  HTML có thể làm: tiêu đề, danh sách có thứ tự (số đếm) hoặc không thứ tự (buleted), liên kết, thậm chí là bảng biểu.
+Như vậy, thay vì viết tài liệu web bằng HTML với nguy cơ tạo ra tài liệu bị lỗi, bạn sẽ dùng các thẻ dễ nhớ hơn và công việc của bạn sẽ hoàn thành nhanh chóng. Với Markdown, bạn sẽ làm được nhiều hoặc ít hơn những gì  HTML có thể làm: tiêu đề, danh sách có thứ tự (số đếm) hoặc không thứ tự (buleted), liên kết, thậm chí là bảng biểu.
 
 Ví dụ, muốn làm tiêu đề cấp 1, bạn sẽ viết một dấu thăng (#), sau đó là tên của tiêu đề, có hoặc không có khoảng trắng giữa chúng:
 
@@ -108,7 +108,7 @@ Tính năng này nỗ lực tạo ra một văn bản Markdown từ nguồn nộ
 - *NVDA+Alt+k*: hiển thị kết quả trên màn hình ảo của NVDA.
 - *NVDA+Shift+g*: chép kết quả vào bộ nhớ tạm.
 
-Bạn cũng có thể chuyển đổi một trang  HTML thành Markdown bằng cách đơn giản là chọn đường dẫn của nó. Tuy nhiên, bạn phải chắc chắn là bộ chuyển đổi HTML2Text phải được chọn làm mặc định trong [Cài đặt của MarkdownForever,](#markdownforevers-default-settings) trong phần tùy chỉnh của NVDA.
+Bạn cũng có thể chuyển đổi một trang  HTML thành Markdown bằng cách đơn giản là chọn đường dẫn của nó. Tuy nhiên, bạn phải chắc chắn là bộ chuyển đổi HTML2Text phải được chọn làm mặc định trong [Cài đặt của MarkdownForever,](#thiet-lap-mac-inh-cua-markdownforever) trong phần tùy chỉnh của NVDA.
  
 ## Chuyển đổi Markdown thành định dạng HTML
 
@@ -122,21 +122,21 @@ Chế độ tương tác là một chức năng dùng để trình bày tất c�
 Sau đây là mô tả màn hình của tính năng, căn cứ theo cách duyệt bằng Tab:
 
 * "Chuyển đổi thành": hộp xổ đầu tiên này cho phép bạn chọn cách chuyển đổi: HTML, Mã nguồn HTML hoặc Markdown. Dùng các phím mũi tên lên xuống để chọn.
-* "Tạo mục lục": Hộp kiểm này sẽ cho phép bạn chọn tạo hay không tạo mục lục của các chương trong tài liệu  HTML của bạn với liên kết có thể click để đi đến chương đó. Trạng thái của tùy chọn này cũng có thể thiết lập mặc định trong [Cài đặt MarkdownForever.](#markdownforevers-default-settings)
+* "Tạo mục lục": Hộp kiểm này sẽ cho phép bạn chọn tạo hay không tạo mục lục của các chương trong tài liệu  HTML của bạn với liên kết có thể click để đi đến chương đó. Trạng thái của tùy chọn này cũng có thể thiết lập mặc định trong [Cài đặt MarkdownForever.](#thiet-lap-mac-inh-cua-markdownforever)
 * "Nỗ lực đánh số tự động cho tiêu đề": nếu chọn, Markdown Forever sẽ nỗ lực thêm số vào trước mỗi tiêu đề (hay chương), tùy theo cấp độ của mỗi tiêu đề. Ví dụ: "1." cho tiêu đề cấp 1, "1.1." cho tiêu đề cấp 2, v...v... 
-* "Bật các thẻ bổ sung": Nếu chọn, sẽ cho phép sử dụng [các thẻ đặc biệt](#extra-tags) trong nội dung Markdown của bạn để tự chèn những thứ như ngày giờ hiện tại. Trạng thái của tùy chọn này cũng có thể thiết lập mặc định trong [Cài đặt MarkdownForever.](#markdownforevers-default-settings)
-* "Cho phép dịch ngược các thẻ bổ sung": tùy chọn này sẽ thể hiện có hay không việc [các thẻ bổ sung](#extra-tags) sẽ được trả lại nguyên mẫu của nó (ví dụ: %date%) khi chuyển đổi nội dung HTML được tạo bởi Markdown Forever trở về Markdown. 
+* "Bật các thẻ bổ sung": Nếu chọn, sẽ cho phép sử dụng [các thẻ đặc biệt](#cac-the-bo-sung) trong nội dung Markdown của bạn để tự chèn những thứ như ngày giờ hiện tại. Trạng thái của tùy chọn này cũng có thể thiết lập mặc định trong [Cài đặt MarkdownForever.](#thiet-lap-mac-inh-cua-markdownforever)
+* "Cho phép dịch ngược các thẻ bổ sung": tùy chọn này sẽ thể hiện có hay không việc [các thẻ bổ sung](#cac-the-bo-sung) sẽ được trả lại nguyên mẫu của nó (ví dụ: %date%) khi chuyển đổi nội dung HTML được tạo bởi Markdown Forever trở về Markdown. 
 * "Tên": bạn có thể điền	 tên cho tài liệu HTML của bạn ở đây, và nó sẽ hiển thị trên trình duyệt.
 * "Khối siêu dữ liệu tương ứng": ô có thuộc tính chỉ đọc này hiển thị 
-* "Tạo siêu dữ liệu tương ứng từ mã nguồn HTML": khi chuyển đổi một  tập tin mã nguồn HTML thành Markdown, nó nỗ lực đoán siêu dữ liệu từ mã nguồn (title - tên, lang - ngôn ngữ, filename -tên tập tin, v...v...) và tạo ra [khối siêu dữ liệu](#optionnal-metadata-block) cho bạn. Tùy chọn này chỉ có khi chuyển đổi HTML thành Markdown.
+* "Tạo siêu dữ liệu tương ứng từ mã nguồn HTML": khi chuyển đổi một  tập tin mã nguồn HTML thành Markdown, nó nỗ lực đoán siêu dữ liệu từ mã nguồn (title - tên, lang - ngôn ngữ, filename -tên tập tin, v...v...) và tạo ra [khối siêu dữ liệu](#tuy-chon-khoi-sieu-du-lieu) cho bạn. Tùy chọn này chỉ có khi chuyển đổi HTML thành Markdown.
 * "Hiển thị trên màn hình ảo": nút này sẽ hiện nội dung đã chuyển đổi của bạn trên màn hình ảo của NVDA.
 * "Hiển thị trên trình duyệt": hiển thị nội dung đã chuyển đổi của bạn trên trình duyệt mặc định.
 * "Chép vào bộ nhớ tạm": chép nội dung đã chuyển đổi của bạn vào bộ nhớ tạm của Windows, sẵn sàng để dán.
-* "Lưu kết quả": sẽ yêu cầu bạn lưu tài liệu đã chuyển đổi vào ổ cứng thông qua một hộp thoại lưu tiêu chuẩn của Windows. Bạn cũng có thể thiết lập nơi lưu mặc định trong [Cài đặt MarkdownForever.](#markdownforevers-default-settings)
+* "Lưu kết quả": sẽ yêu cầu bạn lưu tài liệu đã chuyển đổi vào ổ cứng thông qua một hộp thoại lưu tiêu chuẩn của Windows. Bạn cũng có thể thiết lập nơi lưu mặc định trong [Cài đặt MarkdownForever.](#thiet-lap-mac-inh-cua-markdownforever)
 
 ## Tùy chọn khối siêu dữ liệu
 
-Khối siêu dữ liệu cho phép bạn thiết lập vài tham số nhất định cho một tài liệu cụ thể, độc lập với [các thiết lập mặc định.](#markdownforevers-default-settings) Chúng phải được đặt ở đầu tài liệu và phải bắt đầu với ba dấu trừ ("---") và kết thúc với ba dấu chấm ("...") hoặc ba dấu trừ ("---"). Mỗi thành phần phải được nhập theo mẫu: khóa: "giá trị" (giá trị phải được đặt trong dấu ngoặc kép). Phải đặt một dòng trắng tiếp sau khối siêu dữ liệu.
+Khối siêu dữ liệu cho phép bạn thiết lập vài tham số nhất định cho một tài liệu cụ thể, độc lập với [các thiết lập mặc định.](#thiet-lap-mac-inh-cua-markdownforever) Chúng phải được đặt ở đầu tài liệu và phải bắt đầu với ba dấu trừ ("---") và kết thúc với ba dấu chấm ("...") hoặc ba dấu trừ ("---"). Mỗi thành phần phải được nhập theo mẫu: khóa: "giá trị" (giá trị phải được đặt trong dấu ngoặc kép). Phải đặt một dòng trắng tiếp sau khối siêu dữ liệu.
 
 ### Danh sách siêu dữ liệu được hỗ trợ
 
@@ -144,8 +144,8 @@ Khối siêu dữ liệu cho phép bạn thiết lập vài tham số nhất đ�
 * autonumber-headings: xác định có hay không có việc tự đánh số cho tiêu đề. Có các giá trị: true (1) tức là có hoặc false (0) tức là không.
 * css (hoặc CSS): chỉ ra một hoặc nhiều  tập tin CSS để  trình bày tài liệu của bạn (xem ví dụ bên dưới). Khóa này không phân biệt chữ hoa / thường.
 * date: ghi ra ngày tháng cho tài liệu của bạn. Thông tin này sẽ được thêm vào phần đầu của tập tin HTML.
-* extratags: chỉ định có hay không việc thông dịch [các thẻ bổ sung](#extra-tags). Có các giá trị: true (1) tức là có hoặc false (0) tức là không.
-* extratags-back: xác định có hay không việc dịch ngược  [các thẻ bổ sung](#extra-tags) về nguyên mẫu của nó (ví dụ: %date%) khi chuyển đổi một nội dung HTML được tạo bởi Markdown Forever về Markdown. Có các giá trị: true (1) tức là có hoặc false (0) tức là không.
+* extratags: chỉ định có hay không việc thông dịch [các thẻ bổ sung](#cac-the-bo-sung). Có các giá trị: true (1) tức là có hoặc false (0) tức là không.
+* extratags-back: xác định có hay không việc dịch ngược  [các thẻ bổ sung](#cac-the-bo-sung) về nguyên mẫu của nó (ví dụ: %date%) khi chuyển đổi một nội dung HTML được tạo bởi Markdown Forever về Markdown. Có các giá trị: true (1) tức là có hoặc false (0) tức là không.
 * filename: quy định tên của tập tin khi lưu lại.
 * keywords: quy định các từ khóa liên quan đến những chủ đề được nói đến trong tài liệu của bạn.
 * lang: quy định ngôn ngữ chính cho tài liệu. Nếu cần, hãy dùng các thẻ span/div với thuộc tính lang để xác định các thay đổi ngôn ngữ, ngay bên trong tài liệu.
@@ -211,10 +211,10 @@ Thẻ bổ sung là những bộ giữ chỗ đặc biệt mà bạn có thể �
 
 Có thể truy cập chúng từ trình đơn NVDA -> Cài đặt MarkdownForever -> Cài đặt và bạn sẽ có thể đặt mặc định nhiều thiết lập liên quan tới quá trình chuyển đổi đã đề cập ở trên:
 
-* "Tạo mục lục": tùy chọn này cho phép bạn tạo hay không tạo một mục lục các chương của tài liệu HTML với liên kết dẫn tới mỗi chương. Lựa chọn này cũng có thể thiết lập trên một tài liệu cụ thể bằng cách dùng khóa "toc" trong phần [tùy chọn khối siêu dữ liệu](#optional-metadata-block) và đặt ở bất cứ đâu bằng cách dùng [các thẻ bổ sung tương ứng.](#extra-tags)
-* "Bật các thẻ bổ sung": nếu chọn,, nó sẽ bật khả năng sử dụng [các thẻ đặc biệt](#extra-tags) trong nội dung Markdown của bạn để tự chèn những thứ như ngày giờ hiện tại. Lựa chọn này cũng có thể thiết lập trên một tài liệu cụ thể bằng cách dùng khóa các thẻ bổ sung trong [tùy chọn khối siêu dữ liệu.](#optional-metadata-block)
-* "Tạo siêu dữ liệu tương ứng từ mã nguồn HTML": khi chuyển đổi một tập tin mã nguồn HTML qua Markdown, nó sẽ nỗ lực đoán siêu dữ liệu từ mã nguồn (title - tên, lang - ngôn ngữ, filename - tên tập tin, v...v...) và tạo ra [khối siêu dữ liệu](#optionnal-metadata-block) cho bạn.
-* "Hành động mặc định trong chế độ tương tác": cho phép chọn hành động mặc định sẽ được thực hiện khi bấm phím Enter trong [Chế độ tương tác:](#interactive-mode) hiển thị nội dung đã tạo trên trình duyệt, trên màn hình ảo hay chép vào bộ nhớ tạm.
+* "Tạo mục lục": tùy chọn này cho phép bạn tạo hay không tạo một mục lục các chương của tài liệu HTML với liên kết dẫn tới mỗi chương. Lựa chọn này cũng có thể thiết lập trên một tài liệu cụ thể bằng cách dùng khóa "toc" trong phần [tùy chọn khối siêu dữ liệu](#tuy-chon-khoi-sieu-du-lieu) và đặt ở bất cứ đâu bằng cách dùng [các thẻ bổ sung tương ứng.](#cac-the-bo-sung)
+* "Bật các thẻ bổ sung": nếu chọn,, nó sẽ bật khả năng sử dụng [các thẻ đặc biệt](#cac-the-bo-sung) trong nội dung Markdown của bạn để tự chèn những thứ như ngày giờ hiện tại. Lựa chọn này cũng có thể thiết lập trên một tài liệu cụ thể bằng cách dùng khóa các thẻ bổ sung trong [tùy chọn khối siêu dữ liệu.](#tuy-chon-khoi-sieu-du-lieu)
+* "Tạo siêu dữ liệu tương ứng từ mã nguồn HTML": khi chuyển đổi một tập tin mã nguồn HTML qua Markdown, nó sẽ nỗ lực đoán siêu dữ liệu từ mã nguồn (title - tên, lang - ngôn ngữ, filename - tên tập tin, v...v...) và tạo ra [khối siêu dữ liệu](#tuy-chon-khoi-sieu-du-lieu) cho bạn.
+* "Hành động mặc định trong chế độ tương tác": cho phép chọn hành động mặc định sẽ được thực hiện khi bấm phím Enter trong [Chế độ tương tác:](#che-o-tuong-tac) hiển thị nội dung đã tạo trên trình duyệt, trên màn hình ảo hay chép vào bộ nhớ tạm.
 * "Bộ công cụ Markdown": MarkdownForever cho phép bạn chọn giữa hai bộ chuyển đổi, [HTML2Text](https://pypi.org/project/html2text/) và [HTML2Markdown.](https://pypi.org/project/html2markdown/) Chỉ việc thử nghiệm và chọn cái nào bạn thích, căn cứ trên nhu cầu của bạn hoặc kết quả cho ra.
 * "Markdown2 bổ sung": xem <https://github.com/trentm/python-markdown2/wiki/Extras>.
 * "Đường dẫn": tại đây bạn có thể thiết lập nơi lưu mặc định trên ổ đĩa cho các tài liệu đã chuyển đổi. Nó có ích nếu bạn luôn dùng một thư mục để lưu tất cả công việc của mình.


### PR DESCRIPTION
- Fixed error where some link not point to the correct place due to the table of content's address has been generated automatically using chapter's name.
- Corrected some translation string.